### PR TITLE
eleventy: use blog 'master' branch

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,7 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addPlugin(gitBuildPlugin, {
     repos: [
-      { name: 'blog', branch: 'patch-tags' },
+      { name: 'blog' },
       { name: 'open-governance' },
     ],
     clean: false,


### PR DESCRIPTION
use the master branch from the blog repo instead of the `patch-tags` branch so that new blog posts will be shown on the site

Should wait until https://github.com/redbrick/blog/pull/19 is merged until we merge this