### PR TITLE
nginx: use tidy URLs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,42 +3,27 @@ server {
     listen  [::]:80;
     server_name  localhost;
 
-    #access_log  /var/log/nginx/host.access.log  main;
-
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+        try_files $uri $uri/ $uri.html =404;
     }
 
-    #error_page  404              /404.html;
+    location /open-governance/ {
+        alias /usr/share/nginx/html/open-governance/;
+        index  readme.html;
+        try_files $uri $uri/ $uri.html =404;
+    }
+
+    location /blog/ {
+        alias /usr/share/nginx/html/blog/;
+        index  readme.html;
+        try_files $uri $uri/ $uri.html =404;
+    }
 
     # redirect server error pages to the static page /50x.html
-    #
     error_page  400 401 403 404 500 502 503 504  /404.html;
     location = /404.html {
         root   /usr/share/nginx/html;
     }
-
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }

--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -8,13 +8,13 @@ society:
 navigation:
   global:
     - text: Blog
-      link: /blog/readme.html
+      link: /blog/
     - text: Open Governance
-      link: /open-governance/readme.html
+      link: /open-governance/
     - text: Tech Docs
       link: https://docs.redbrick.dcu.ie
     - text: Links
-      link: /links.html
+      link: /links
   blog:
     - text: Events
       tag: events


### PR DESCRIPTION
now `/blog/` and `/open-governance/` display the `readme.html` as the index
and all pages ending in `.html` can be viewed without the file extension