### PR TITLE
deploy/traefik: don't route /~user to atlas

### DIFF
--- a/.github/deploy/production.hcl
+++ b/.github/deploy/production.hcl
@@ -27,7 +27,7 @@ job "atlas" {
 
       tags = [
         "traefik.enable=true",
-        "traefik.http.routers.nginx-atlas.rule=Host(`redbrick.dcu.ie`) || Host(`www.redbrick.dcu.ie`) || Host(`www.rb.dcu.ie`) || Host(`rb.dcu.ie`) || Host(`redbrick.ie`) || Host(`www.redbrick.ie`)",
+        "traefik.http.routers.nginx-atlas.rule=(Host(`redbrick.dcu.ie`) || Host(`www.redbrick.dcu.ie`) || Host(`www.rb.dcu.ie`) || Host(`rb.dcu.ie`) || Host(`redbrick.ie`) || Host(`www.redbrick.ie`)) && !PathPrefix(`/~`)",
         "traefik.http.routers.nginx-atlas.entrypoints=web,websecure",
         "traefik.http.routers.nginx-atlas.tls.certresolver=rb",
       ]


### PR DESCRIPTION
this is handled by webtree since this commit: https://github.com/redbrick/nomad/pull/130/commits/f7c4f6406d00a7ba55379b61c74d9c8b00c3f82d