### PR TITLE
Show Created and Modified when available on Open Governance

### DIFF
--- a/src/_layouts/markdown/open-governance.njk
+++ b/src/_layouts/markdown/open-governance.njk
@@ -4,17 +4,20 @@ collection: open-governance
 outline: In this document
 ---
 
+{% set tags = [
+  { text: "🔨 Created", value: created },
+  { text: "✏️ Last Edited", value: modified }
+] %}
+
 <div class="prose min-w-full">
   {% if created and modified %}
     <div class="inline-block py-4">
-      <span data-pagefind-ignore class="badge badge-lg badge-ghost">
-        <span class="font-bold">🔨 Created:</span>
-        <span class="font-normal ml-1">{{ created | readable }}</span>
-      </span>
-      <span data-pagefind-ignore class="badge badge-lg badge-ghost">
-        <span class="font-bold">✏️ Last Edited:</span>
-        <span class="font-normal ml-1">{{ modified | readable }}</span>
-      </span>
+      {% for tag in tags %}
+        <span data-pagefind-ignore class="badge badge-lg badge-ghost">
+          <span class="font-bold">{{ tag.text }}:</span>
+          <span class="font-normal ml-1">{{ tag.value | readable }}</span>
+        </span>
+      {% endfor %}
     </div>
   {% endif %}
   {{ content | safe }}


### PR DESCRIPTION
This PR introduces "Created" and "Last Modified" information on Open Governance pages that include such metadata in their markdown.

This closes #1 