### PR TITLE
Allow repository dispatch to deploy to Production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
     container:
       image: hashicorp/levant:0.3
       options: --user root
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'repository_dispatch')
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We have several repositories, including https://github.com/redbrick/blog, https://github.com/redbrick/open-governance, and https://github.com/redbrick/design-system, that utilize a repository dispatch to redeploy Atlas when changes are made. We need to enable the repository dispatch to execute the `deploy_prod` job so that updates are reflected immediately, without waiting for another push to the repository.